### PR TITLE
CREATE SOURCES should support filter

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -615,7 +615,9 @@ impl fmt::Display for Statement {
                     write!(
                         f,
                         "LIKE {} ",
-                        like, // This needs to be the string from the LikeFilter
+                        match like {
+                            LikeFilter::Like(value) => Value::SingleQuotedString(value.clone()).to_string(),
+                        },
                     )?;
                 }
                 write!(

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -607,16 +607,9 @@ impl fmt::Display for Statement {
                 schema_registry,
                 with_options,
             } => {
-                write!(
-                    f,
-                    "CREATE SOURCES "
-                )?;
+                write!(f, "CREATE SOURCES ")?;
                 if let Some(like) = like {
-                    write!(
-                        f,
-                        "LIKE '{}' ",
-                        value::escape_single_quote_string(like),
-                    )?;
+                    write!(f, "LIKE '{}' ", value::escape_single_quote_string(like),)?;
                 }
                 write!(
                     f,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -614,10 +614,8 @@ impl fmt::Display for Statement {
                 if let Some(like) = like {
                     write!(
                         f,
-                        "LIKE {} ",
-                        match like {
-                            LikeFilter::Like(value) => Value::SingleQuotedString(value.clone()).to_string(),
-                        },
+                        "{} ",
+                        like,
                     )?;
                 }
                 write!(
@@ -990,7 +988,7 @@ impl fmt::Display for LikeFilter {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use LikeFilter::*;
         match self {
-            Like(pattern) => write!(f, "LIKE '{}", value::escape_single_quote_string(pattern)),
+            Like(pattern) => write!(f, "LIKE '{}'", value::escape_single_quote_string(pattern)),
         }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -411,7 +411,7 @@ pub enum Statement {
     },
     /// `CREATE SOURCES`
     CreateSources {
-        like: Option<LikeFilter>,
+        like: Option<String>,
         url: String,
         schema_registry: String,
         with_options: Vec<SqlOption>,
@@ -614,8 +614,8 @@ impl fmt::Display for Statement {
                 if let Some(like) = like {
                     write!(
                         f,
-                        "{} ",
-                        like,
+                        "LIKE '{}' ",
+                        value::escape_single_quote_string(like),
                     )?;
                 }
                 write!(
@@ -976,20 +976,6 @@ impl fmt::Display for TransactionIsolationLevel {
             RepeatableRead => "REPEATABLE READ",
             Serializable => "SERIALIZABLE",
         })
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum LikeFilter {
-    Like(String)
-}
-
-impl fmt::Display for LikeFilter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use LikeFilter::*;
-        match self {
-            Like(pattern) => write!(f, "LIKE '{}'", value::escape_single_quote_string(pattern)),
-        }
     }
 }
 

--- a/src/ast/visit.rs
+++ b/src/ast/visit.rs
@@ -22,6 +22,7 @@
 #![allow(clippy::ptr_arg)]
 
 use super::*;
+use crate::ast::LikeFilter::Like;
 
 /// A trait that represents a visitor that walks through a SQL AST.
 ///
@@ -318,11 +319,16 @@ pub trait Visit<'ast> {
 
     fn visit_create_sources(
         &mut self,
+        like: Option<&'ast LikeFilter>,
         url: &'ast String,
         schema_registry: &'ast String,
         with_options: &'ast Vec<SqlOption>,
     ) {
-        visit_create_sources(self, url, schema_registry, with_options)
+        visit_create_sources(self, like, url, schema_registry, with_options)
+    }
+
+    fn visit_like_filter(&mut self, like: &'ast LikeFilter) {
+        visit_like_filter(self, like)
     }
 
     fn visit_source_schema(&mut self, source_schema: &'ast SourceSchema) {
@@ -541,10 +547,11 @@ pub fn visit_statement<'ast, V: Visit<'ast> + ?Sized>(visitor: &mut V, statement
             with_options,
         } => visitor.visit_create_source(name, url, schema, with_options),
         Statement::CreateSources {
+            like,
             url,
             schema_registry,
             with_options,
-        } => visitor.visit_create_sources(url, schema_registry, with_options),
+        } => visitor.visit_create_sources(like.as_ref(), url, schema_registry, with_options),
         Statement::CreateSink {
             name,
             from,
@@ -1157,14 +1164,28 @@ pub fn visit_create_source<'ast, V: Visit<'ast> + ?Sized>(
 
 pub fn visit_create_sources<'ast, V: Visit<'ast> + ?Sized>(
     visitor: &mut V,
+    like: Option<&'ast LikeFilter>,
     url: &'ast String,
     schema_registry: &'ast String,
     with_options: &'ast Vec<SqlOption>,
 ) {
+    if let Some(like) = like {
+        visitor.visit_like_filter(like);
+    }
     visitor.visit_literal_string(url);
     visitor.visit_literal_string(schema_registry);
     for option in with_options {
         visitor.visit_option(option);
+    }
+}
+
+pub fn visit_like_filter<'ast, V: Visit<'ast> + ?Sized>(
+    visitor: &mut V,
+    like: &'ast LikeFilter,
+) {
+    match like {
+        LikeFilter::Like(pattern) => visitor.visit_literal_string(pattern),
+        _ => (),
     }
 }
 

--- a/src/ast/visit.rs
+++ b/src/ast/visit.rs
@@ -22,7 +22,6 @@
 #![allow(clippy::ptr_arg)]
 
 use super::*;
-use crate::ast::LikeFilter::Like;
 
 /// A trait that represents a visitor that walks through a SQL AST.
 ///
@@ -319,16 +318,12 @@ pub trait Visit<'ast> {
 
     fn visit_create_sources(
         &mut self,
-        like: Option<&'ast LikeFilter>,
+        like: Option<&'ast String>,
         url: &'ast String,
         schema_registry: &'ast String,
         with_options: &'ast Vec<SqlOption>,
     ) {
         visit_create_sources(self, like, url, schema_registry, with_options)
-    }
-
-    fn visit_like_filter(&mut self, like: &'ast LikeFilter) {
-        visit_like_filter(self, like)
     }
 
     fn visit_source_schema(&mut self, source_schema: &'ast SourceSchema) {
@@ -1164,28 +1159,18 @@ pub fn visit_create_source<'ast, V: Visit<'ast> + ?Sized>(
 
 pub fn visit_create_sources<'ast, V: Visit<'ast> + ?Sized>(
     visitor: &mut V,
-    like: Option<&'ast LikeFilter>,
+    like: Option<&'ast String>,
     url: &'ast String,
     schema_registry: &'ast String,
     with_options: &'ast Vec<SqlOption>,
 ) {
     if let Some(like) = like {
-        visitor.visit_like_filter(like);
+        visitor.visit_literal_string(like);
     }
     visitor.visit_literal_string(url);
     visitor.visit_literal_string(schema_registry);
     for option in with_options {
         visitor.visit_option(option);
-    }
-}
-
-pub fn visit_like_filter<'ast, V: Visit<'ast> + ?Sized>(
-    visitor: &mut V,
-    like: &'ast LikeFilter,
-) {
-    match like {
-        LikeFilter::Like(pattern) => visitor.visit_literal_string(pattern),
-        _ => (),
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -47,7 +47,6 @@ pub enum IsLateral {
     NotLateral,
 }
 use IsLateral::*;
-use crate::ast::LikeFilter::Like;
 
 impl From<TokenizerError> for ParserError {
     fn from(e: TokenizerError) -> Self {
@@ -920,11 +919,11 @@ impl Parser {
         })
     }
 
-    fn parse_like_filter(&mut self) -> Result<Option<LikeFilter>, ParserError> {
+    fn parse_like_filter(&mut self) -> Result<Option<String>, ParserError> {
         if self.parse_keyword("LIKE") {
-            Ok(Some(LikeFilter::Like(
+            Ok(Some(
                 self.parse_literal_string()?
-            )))
+            ))
         } else {
             Ok(None)
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -921,9 +921,7 @@ impl Parser {
 
     fn parse_like_filter(&mut self) -> Result<Option<String>, ParserError> {
         if self.parse_keyword("LIKE") {
-            Ok(Some(
-                self.parse_literal_string()?
-            ))
+            Ok(Some(self.parse_literal_string()?))
         } else {
             Ok(None)
         }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2217,7 +2217,7 @@ fn parse_create_sources() {
 
 #[test]
 fn parse_create_sources_with_like_regex() {
-    let sql = "CREATE SOURCES LIKE %foo% FROM 'kafka://whatever' USING SCHEMA REGISTRY 'http://foo.bar:8081'";
+    let sql = "CREATE SOURCES LIKE '%foo%' FROM 'kafka://whatever' USING SCHEMA REGISTRY 'http://foo.bar:8081'";
     match verified_stmt(sql) {
         Statement::CreateSources {
             like,
@@ -2225,10 +2225,9 @@ fn parse_create_sources_with_like_regex() {
             schema_registry,
             with_options,
         } => {
-            println!("{:#?}", like);
             let like = like.unwrap();
             match like {
-                LikeFilter::Like(value) => assert_eq!("foo", value)
+                LikeFilter::Like(value) => assert_eq!("%foo%", value)
             }
             assert_eq!("kafka://whatever", url);
             assert_eq!("http://foo.bar:8081", schema_registry);

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2207,6 +2207,7 @@ fn parse_create_sources() {
             schema_registry,
             with_options,
         } => {
+            assert!(like.is_none());
             assert_eq!("kafka://whatever", url);
             assert_eq!("http://foo.bar:8081", schema_registry);
             assert!(with_options.is_empty());
@@ -2225,9 +2226,9 @@ fn parse_create_sources_with_like_regex() {
             schema_registry,
             with_options,
         } => {
-            let like = like.unwrap();
             match like {
-                LikeFilter::Like(value) => assert_eq!("%foo%", value)
+                Some(value) => assert_eq!("%foo%", value),
+                None => unimplemented!(),
             }
             assert_eq!("kafka://whatever", url);
             assert_eq!("http://foo.bar:8081", schema_registry);

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2202,10 +2202,34 @@ fn parse_create_sources() {
     let sql = "CREATE SOURCES FROM 'kafka://whatever' USING SCHEMA REGISTRY 'http://foo.bar:8081'";
     match verified_stmt(sql) {
         Statement::CreateSources {
+            like,
             url,
             schema_registry,
             with_options,
         } => {
+            assert_eq!("kafka://whatever", url);
+            assert_eq!("http://foo.bar:8081", schema_registry);
+            assert!(with_options.is_empty());
+        }
+        _ => assert!(false),
+    }
+}
+
+#[test]
+fn parse_create_sources_with_like_regex() {
+    let sql = "CREATE SOURCES LIKE %foo% FROM 'kafka://whatever' USING SCHEMA REGISTRY 'http://foo.bar:8081'";
+    match verified_stmt(sql) {
+        Statement::CreateSources {
+            like,
+            url,
+            schema_registry,
+            with_options,
+        } => {
+            println!("{:#?}", like);
+            let like = like.unwrap();
+            match like {
+                LikeFilter::Like(value) => assert_eq!("foo", value)
+            }
             assert_eq!("kafka://whatever", url);
             assert_eq!("http://foo.bar:8081", schema_registry);
             assert!(with_options.is_empty());


### PR DESCRIPTION
This is the first half of the work for: https://github.com/MaterializeInc/materialize/issues/31.

This PR updates the code that parses `CREATE SOURCE FROM..` to optionally parse a LIKE as follows: `CREATE SOURCE [LIKE '%pattern%']...`.



