### PR TITLE
WIP: Support CREATE/DROP INDEX

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -499,6 +499,15 @@ pub enum Statement {
         file_format: Option<FileFormat>,
         location: Option<String>,
     },
+    /// `CREATE INDEX`
+    CreateIndex {
+        /// Index name
+        name: Ident,
+        /// `ON` table or view name
+        on_name: ObjectName,
+        /// Expressions that form part of the index key
+        key_parts: Vec<Expr>,
+    },
     /// `ALTER TABLE`
     AlterTable {
         /// Table name
@@ -759,6 +768,20 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
+            Statement::CreateIndex {
+                name,
+                on_name,
+                key_parts,
+            } => {
+                write!(
+                    f,
+                    "CREATE INDEX {} ON {} ({})",
+                    name,
+                    on_name,
+                    display_comma_separated(key_parts),
+                )?;
+                Ok(())
+            }
             Statement::AlterTable { name, operation } => {
                 write!(f, "ALTER TABLE {} {}", name, operation)
             }
@@ -797,6 +820,7 @@ impl fmt::Display for Statement {
                         View => "VIEWS",
                         Source => "SOURCES",
                         Sink => "SINKS",
+                        Index => unreachable!(),
                     }
                 )
             }
@@ -963,6 +987,7 @@ pub enum ObjectType {
     View,
     Source,
     Sink,
+    Index,
 }
 
 impl fmt::Display for ObjectType {
@@ -972,6 +997,7 @@ impl fmt::Display for ObjectType {
             ObjectType::View => "VIEW",
             ObjectType::Source => "SOURCE",
             ObjectType::Sink => "SINK",
+            ObjectType::Index => "INDEX",
         })
     }
 }

--- a/src/ast/visit_macro.rs
+++ b/src/ast/visit_macro.rs
@@ -382,6 +382,15 @@ macro_rules! make_visitor {
                 visit_create_view(self, name, columns, query, materialized, with_options)
             }
 
+            fn visit_create_index(
+                &mut self,
+                name: &'ast $($mut)* Ident,
+                on_name: &'ast $($mut)* ObjectName,
+                key_parts: &'ast $($mut)* Vec<Expr>
+            ){
+                visit_create_index(self, name, on_name, key_parts)
+            }
+
             fn visit_create_table(
                 &mut self,
                 name: &'ast $($mut)* ObjectName,
@@ -602,6 +611,11 @@ macro_rules! make_visitor {
                     materialized,
                     with_options,
                 } => visitor.visit_create_view(name, columns, query, *materialized, with_options),
+                Statement::CreateIndex {
+                    name,
+                    on_name,
+                    key_parts,
+                } => visitor.visit_create_index(name, on_name, key_parts),
                 Statement::Drop {
                     object_type,
                     if_exists,
@@ -1286,6 +1300,19 @@ macro_rules! make_visitor {
                 visitor.visit_option(option);
             }
             visitor.visit_query(query);
+        }
+
+        pub fn visit_create_index<'ast, V: $name<'ast> + ?Sized>(
+            visitor: &mut V,
+            name: &'ast $($mut)* Ident,
+            on_name: &'ast $($mut)* ObjectName,
+            key_parts: &'ast $($mut)* Vec<Expr>,
+        ) {
+            visitor.visit_ident(name);
+            visitor.visit_object_name(on_name);
+            for key_part in key_parts {
+                visitor.visit_expr(key_part);
+            }
         }
 
         pub fn visit_create_table<'ast, V: $name<'ast> + ?Sized>(

--- a/src/dialect/keywords.rs
+++ b/src/dialect/keywords.rs
@@ -203,6 +203,7 @@ define_keywords!(
     IF,
     IMMEDIATE,
     IN,
+    INDEX,
     INDICATOR,
     INNER,
     INOUT,


### PR DESCRIPTION
Part of the work involved in MaterializeInc/materialize#218

Basic support for the `CREATE INDEX` and `DROP INDEX` syntax. 

Note that index creation and management syntax is not part of the SQL standard.

# Syntax for CREATE INDEX
CREATE INDEX _index_name_ ON *table_name(key_part, …)*
*key_part: {col_name | (expr)}*

This is a subset of the overlap between PostgreSQL and MySQL. Links to the full syntax for both DBs are below in case we think that we may want to support some additional features or allow sqlparser to be able to support future implementations of the certain features. 
https://www.postgresql.org/docs/12/sql-createindex.html
https://dev.mysql.com/doc/refman/8.0/en/create-index.html

In PostgreSQL, all expressions other than column names (without qualifiers) and functions must have parentheses around them, and I have followed that parsing rule in the PR. I'm not sure if MySQL exempts functions from the parentheses requirement. 

# Syntax for DROP INDEX
DROP INDEX [IF EXISTS] index_name  [, …] (CASCADE | RESTRICT)

This is a subset of what PostgreSQL supports and a superset of what MySQL supports. This syntax is motivated by it being the default state for DROP <object type> and it being more of a hassle to not support the options.

# Question: Do we want to support SHOW INDEX/INDEXES/KEYS? 

Currently in this branch `SHOW INDEX` is not supported.

`SHOW INDEX` is supported in MySQL  (and CockroachDB), but it is not supported in PostgreSQL, Oracle, or Microsoft SQL Server.
The MySQL syntax is here:
https://dev.mysql.com/doc/refman/8.0/en/show-index.html

Since indexes belong to tables, it seems like supporting `SHOW INDEX` would involve reworking the `Statement::ShowObjects` or `ObjectType` enums.