### PR TITLE
Use ShowStatementFilter in ShowObjects

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -622,7 +622,7 @@ pub enum Statement {
     /// ```
     ShowObjects {
         object_type: ObjectType,
-        like: Option<String>,
+        filter: Option<ShowStatementFilter>,
     },
     /// `SHOW COLUMNS`
     ///
@@ -883,7 +883,10 @@ impl fmt::Display for Statement {
                 write!(f, "{} = {}", variable, value)
             }
             Statement::ShowVariable { variable } => write!(f, "SHOW {}", variable),
-            Statement::ShowObjects { object_type, like } => {
+            Statement::ShowObjects {
+                object_type,
+                filter,
+            } => {
                 use ObjectType::*;
                 write!(
                     f,
@@ -896,8 +899,8 @@ impl fmt::Display for Statement {
                         Index => unreachable!(),
                     }
                 )?;
-                if let Some(like) = like {
-                    write!(f, " LIKE '{}'", value::escape_single_quote_string(like))?;
+                if let Some(filter) = filter {
+                    write!(f, " {}", filter)?;
                 }
                 Ok(())
             }

--- a/src/ast/visit_macro.rs
+++ b/src/ast/visit_macro.rs
@@ -505,7 +505,9 @@ macro_rules! make_visitor {
                 visit_show_variable(self, variable)
             }
 
-            fn visit_show_objects(&mut self, _object_type: ObjectType, _like: &Option<String>) {}
+            fn visit_show_objects(&mut self, object_type: ObjectType, filter: Option<&'ast $($mut)* ShowStatementFilter>) {
+                visit_show_objects(self, object_type, filter)
+            }
 
             fn visit_show_columns(
                 &mut self,
@@ -654,7 +656,9 @@ macro_rules! make_visitor {
                     value,
                 } => visitor.visit_set_variable(*local, variable, value),
                 Statement::ShowVariable { variable } => visitor.visit_show_variable(variable),
-                Statement::ShowObjects { object_type, like } => visitor.visit_show_objects(*object_type, like),
+                Statement::ShowObjects { object_type, filter } => {
+                    visitor.visit_show_objects(*object_type, filter.as_auto_ref())
+                }
                 Statement::ShowColumns {
                     extended,
                     full,
@@ -1534,6 +1538,17 @@ macro_rules! make_visitor {
 
         pub fn visit_show_variable<'ast, V: $name<'ast> + ?Sized>(visitor: &mut V, variable: &'ast $($mut)* Ident) {
             visitor.visit_ident(variable);
+        }
+
+        pub fn visit_show_objects<'ast, V: $name<'ast> + ?Sized>(
+            visitor: &mut V,
+            object_type: ObjectType,
+            filter: Option<&'ast $($mut)* ShowStatementFilter>
+        ) {
+            visitor.visit_object_type(object_type);
+            if let Some(filter) = filter {
+                visitor.visit_show_statement_filter(filter);
+            }
         }
 
         pub fn visit_show_columns<'ast, V: $name<'ast> + ?Sized>(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1548,7 +1548,7 @@ impl Parser {
                 "TIMESTAMP" => {
                     if self.parse_keyword("WITH") {
                         self.expect_keywords(&["TIME", "ZONE"])?;
-                        return Ok(DataType::TimestampTz)
+                        return Ok(DataType::TimestampTz);
                     } else if self.parse_keyword("WITHOUT") {
                         self.expect_keywords(&["TIME", "ZONE"])?;
                     }
@@ -1557,7 +1557,7 @@ impl Parser {
                 "TIME" => {
                     if self.parse_keyword("WITH") {
                         self.expect_keywords(&["TIME", "ZONE"])?;
-                        return Ok(DataType::TimeTz)
+                        return Ok(DataType::TimeTz);
                     } else if self.parse_keyword("WITHOUT") {
                         self.expect_keywords(&["TIME", "ZONE"])?;
                     }
@@ -1940,7 +1940,7 @@ impl Parser {
                         val
                     ),
                 },
-                like: self.parse_like_filter()?,
+                filter: self.parse_show_statement_filter()?,
             })
         } else if self.parse_keywords(vec!["CREATE", "VIEW"]) {
             Ok(Statement::ShowCreateView {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1914,9 +1914,24 @@ fn parse_show_objects() {
             verified_stmt(&sql),
             Statement::ShowObjects {
                 object_type: *ot,
-                like: None
+                filter: None
             }
         )
+    }
+}
+
+#[test]
+fn parse_show_objects_with_like_regex() {
+    let sql = "SHOW TABLES LIKE '%foo%'";
+    match verified_stmt(sql) {
+        Statement::ShowObjects {
+            object_type,
+            filter,
+        } => {
+            assert_eq!(filter.unwrap(), ShowStatementFilter::Like("%foo%".into()));
+            assert_eq!(ObjectType::Table, object_type);
+        }
+        _ => panic!("invalid SHOW OBJECTS statement"),
     }
 }
 
@@ -2744,18 +2759,6 @@ fn parse_create_sources_with_like_regex() {
             assert!(with_options.is_empty());
         }
         _ => assert!(false),
-    }
-}
-
-#[test]
-fn parse_show_objects_with_like_regex() {
-    let sql = "SHOW TABLES LIKE '%foo%'";
-    match verified_stmt(sql) {
-        Statement::ShowObjects { object_type, like } => {
-            assert_eq!(like.unwrap(), "%foo%");
-            assert_eq!(ObjectType::Table, object_type);
-        }
-        _ => panic!("invalid SHOW OBJECTS statement"),
     }
 }
 


### PR DESCRIPTION
@JLDLaughlin I noticed this opportunity to share a bit more code with ShowColumns while looking at MaterializeInc/materialize#921! Apologies for not socializing it. I think this strictly increases the expressivity of your patch.

----

Make ShowObjects and ShowColumns consistent in their use of
ShowStatementFilter, which supports both a shorthand LIKE expression as
well as a more general SQL expression.

Also rustfmt, which hadn't been run in a while. (My fault too!)