### PR TITLE
make schema optional

### DIFF
--- a/src/ast/visit_macro.rs
+++ b/src/ast/visit_macro.rs
@@ -343,7 +343,7 @@ macro_rules! make_visitor {
                 &mut self,
                 name: &'ast $($mut)* ObjectName,
                 url: &'ast $($mut)* String,
-                schema: &'ast $($mut)* SourceSchema,
+                schema: Option<&'ast $($mut)* SourceSchema>,
                 with_options: &'ast $($mut)* Vec<SqlOption>,
             ) {
                 visit_create_source(self, name, url, schema, with_options)
@@ -612,7 +612,7 @@ macro_rules! make_visitor {
                     url,
                     schema,
                     with_options,
-                } => visitor.visit_create_source(name, url, schema, with_options),
+                } => visitor.visit_create_source(name, url, schema.as_auto_ref(), with_options),
                 Statement::CreateSources {
                     like,
                     url,
@@ -1255,12 +1255,14 @@ macro_rules! make_visitor {
             visitor: &mut V,
             name: &'ast $($mut)* ObjectName,
             url: &'ast $($mut)* String,
-            schema: &'ast $($mut)* SourceSchema,
+            schema: Option<&'ast $($mut)* SourceSchema>,
             with_options: &'ast $($mut)* Vec<SqlOption>,
         ) {
             visitor.visit_object_name(name);
             visitor.visit_literal_string(url);
-            visitor.visit_source_schema(schema);
+            if let Some(schema) = schema {
+                visitor.visit_source_schema(schema);
+            }
             for option in with_options {
                 visitor.visit_option(option);
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1145,12 +1145,15 @@ impl Parser {
         let name = self.parse_object_name()?;
         self.expect_keyword("FROM")?;
         let url = self.parse_literal_string()?;
-        self.expect_keyword("USING")?;
-        self.expect_keyword("SCHEMA")?;
-        let schema = if self.parse_keyword("REGISTRY") {
-            SourceSchema::Registry(self.parse_literal_string()?)
+        let schema = if self.parse_keywords(vec!["USING", "SCHEMA"]) {
+            let schema = if self.parse_keyword("REGISTRY") {
+                SourceSchema::Registry(self.parse_literal_string()?)
+            } else {
+                SourceSchema::Raw(self.parse_literal_string()?)
+            };
+            Some(schema)
         } else {
-            SourceSchema::Raw(self.parse_literal_string()?)
+            None
         };
         let with_options = self.parse_with_options()?;
         Ok(Statement::CreateSource {


### PR DESCRIPTION
Will allow syntax like: `CREATE SOURCE foo FROM 'file+csv:///home/brennan/test.csv' WITH ( columns=5);` in materialize.