### PR TITLE
Allow intervals like INTERVAL '-30 day'

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -451,14 +451,25 @@ impl Parser {
     pub fn parse_date_time_field(&mut self) -> Result<DateTimeField, ParserError> {
         let tok = self.next_token();
         if let Some(Token::Word(ref k)) = tok {
-            self.parse_date_time_given_str(k.keyword.as_ref())
+            match k.keyword.as_ref() {
+                "YEAR" => Ok(DateTimeField::Year),
+                "MONTH" => Ok(DateTimeField::Month),
+                "DAY" => Ok(DateTimeField::Day),
+                "HOUR" => Ok(DateTimeField::Hour),
+                "MINUTE" => Ok(DateTimeField::Minute),
+                "SECOND" => Ok(DateTimeField::Second),
+                _ => self.expected("date/time field", tok)?,
+            }
         } else {
             self.expected("date/time field", tok)?
         }
     }
 
-    // Hacked internal of parse_date_time_field to allow directly passing strs.
-    pub fn parse_date_time_given_str(&mut self, s: &str) -> Result<DateTimeField, ParserError> {
+    // Hacked version of parse_date_time_field to allow directly passing strs.
+    pub fn parse_date_time_field_given_str(
+        &mut self,
+        s: &str,
+    ) -> Result<DateTimeField, ParserError> {
         match s {
             "YEAR" => Ok(DateTimeField::Year),
             "MONTH" => Ok(DateTimeField::Month),
@@ -669,7 +680,7 @@ impl Parser {
                 if split.len() == 2 {
                     (
                         String::from(split[0]),
-                        self.parse_date_time_given_str(&split[1].to_uppercase())?,
+                        self.parse_date_time_field_given_str(&split[1].to_uppercase())?,
                     )
                 } else {
                     return parser_err!("Invalid INTERVAL: {:#?}", raw_value);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -451,17 +451,22 @@ impl Parser {
     pub fn parse_date_time_field(&mut self) -> Result<DateTimeField, ParserError> {
         let tok = self.next_token();
         if let Some(Token::Word(ref k)) = tok {
-            match k.keyword.as_ref() {
-                "YEAR" => Ok(DateTimeField::Year),
-                "MONTH" => Ok(DateTimeField::Month),
-                "DAY" => Ok(DateTimeField::Day),
-                "HOUR" => Ok(DateTimeField::Hour),
-                "MINUTE" => Ok(DateTimeField::Minute),
-                "SECOND" => Ok(DateTimeField::Second),
-                _ => self.expected("date/time field", tok)?,
-            }
+            self.parse_date_time_given_str(k.keyword.as_ref())
         } else {
             self.expected("date/time field", tok)?
+        }
+    }
+
+    // Hacked internal of parse_date_time_field to allow directly passing strs.
+    pub fn parse_date_time_given_str(&mut self, s: &str) -> Result<DateTimeField, ParserError> {
+        match s {
+            "YEAR" => Ok(DateTimeField::Year),
+            "MONTH" => Ok(DateTimeField::Month),
+            "DAY" => Ok(DateTimeField::Day),
+            "HOUR" => Ok(DateTimeField::Hour),
+            "MINUTE" => Ok(DateTimeField::Minute),
+            "SECOND" => Ok(DateTimeField::Second),
+            _ => parser_err!("Expected date/time field, found: {}", s),
         }
     }
 
@@ -644,14 +649,28 @@ impl Parser {
 
         // The first token in an interval is a string literal which specifies
         // the duration of the interval.
-        let raw_value = self.parse_literal_string()?;
-
-        // Following the string literal is a qualifier which indicates the units
-        // of the duration specified in the string literal.
-        //
-        // Note that PostgreSQL allows omitting the qualifier, but we currently
-        // require at least the leading field, in accordance with the ANSI spec.
-        let leading_field = self.parse_date_time_field()?;
+        let mut raw_value = self.parse_literal_string()?;
+        let leading_field = if raw_value.contains(" ") {
+            // Hack to allow INTERVAL types like:
+            // INTERVAL '-30 day'
+            let (new_raw_value, leading_field) = {
+                let split = raw_value.split(" ").collect::<Vec<&str>>();
+                if split.len() == 2 {
+                    (String::from(split[0]), self.parse_date_time_given_str(&split[1].to_uppercase())?)
+                } else {
+                    return parser_err!("Invalid INTERVAL: {:#?}", raw_value);
+                }
+            };
+            raw_value = new_raw_value;
+            leading_field
+        } else {
+            // Following the string literal is a qualifier which indicates the units
+            // of the duration specified in the string literal.
+            //
+            // Note that PostgreSQL allows omitting the qualifier, but we currently
+            // require at least the leading field, in accordance with the ANSI spec.
+            self.parse_date_time_field()?
+        };
 
         let (leading_precision, last_field, fsec_precision) =
             if leading_field == DateTimeField::Second {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1524,6 +1524,18 @@ fn parse_literal_interval_monthlike() {
         None,
         Some("The interval string '1-1' specifies MONTHs but the requested precision would truncate to YEAR"),
     );
+
+    iv.value = "-1".to_string();
+    iv.leading_field = DateTimeField::Month;
+    iv.parsed.is_positive = false;
+    iv.parsed.year = None;
+    verify_interval(
+        "SELECT INTERVAL '-1' MONTH",
+        iv.clone(),
+        Interval::Months(-1),
+        None,
+        None,
+    )
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2820,7 +2820,7 @@ fn parse_create_source_raw_schema() {
         } => {
             assert_eq!("foo", name.to_string());
             assert_eq!("bar", url);
-            assert_eq!(SourceSchema::Raw("baz".into()), schema);
+            assert_eq!(SourceSchema::Raw("baz".into()), schema.unwrap());
             assert_eq!(
                 with_options,
                 vec![SqlOption {
@@ -2847,7 +2847,7 @@ fn parse_create_source_registry() {
             assert_eq!("bar", url);
             assert_eq!(
                 SourceSchema::Registry("http://localhost:8081".into()),
-                schema
+                schema.unwrap()
             );
             assert_eq!(with_options, vec![]);
         }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1524,18 +1524,6 @@ fn parse_literal_interval_monthlike() {
         None,
         Some("The interval string '1-1' specifies MONTHs but the requested precision would truncate to YEAR"),
     );
-
-    iv.value = "-1".to_string();
-    iv.leading_field = DateTimeField::Month;
-    iv.parsed.is_positive = false;
-    iv.parsed.year = None;
-    verify_interval(
-        "SELECT INTERVAL '-1' MONTH",
-        iv.clone(),
-        Interval::Months(-1),
-        None,
-        None,
-    )
 }
 
 #[test]


### PR DESCRIPTION
Metabase queries Materialize using intervals like `INTERVAL '-30 day'` in order to bucket data for particular visualizations. This PR is a hacky way to support that new type of interval.

I tested this by writing a testdrive test that still fails (for a new reason!). Before change:
```
==> test/scratch.td
test/scratch.td:58:1: error: unable to parse SQL: SELECT * FROM data WHERE d > CAST((CAST(d AS timestamp) + (INTERVAL '-30 day')) AS date): sql parser error: Expected date/time field, found: )
     |
  57 |
  58 | > SELECT * FROM data WHERE d > CAST((CAST(d AS timestamp) + (INTERVAL '-30 day')) AS date)
```

After change (no testdrive error, Materialize prints `WARN`):
```
[2019-12-04T17:01:09.189877Z  WARN pgwire/codec:203] error for client: Error->CAST does not support casting from Timestamp to Date
```
(We already have tickets for the new warning).