### PR TITLE
parse approximate numeric literal

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -347,11 +347,35 @@ impl<'a> Tokenizer<'a> {
                 }
                 // numbers
                 '0'..='9' => {
-                    // TODO: https://jakewheat.github.io/sql-overview/sql-2011-foundation-grammar.html#unsigned-numeric-literal
-                    let s = peeking_take_while(chars, |ch| match ch {
-                        '0'..='9' | '.' => true,
+                    let mut seen_decimal = false;
+                    let mut s = peeking_take_while(chars, |ch| match ch {
+                        '0'..='9' => true,
+                        '.' if !seen_decimal => {
+                            seen_decimal = true;
+                            true
+                        }
                         _ => false,
                     });
+                    // If in e-notation, parse the e-notation with special care given to negative exponents.
+                    match chars.peek() {
+                        Some('e') | Some('E') => {
+                            s.push('E');
+                            // Consume the e-notation signifier.
+                            chars.next();
+                            if let Some('-') = chars.peek() {
+                                s.push('-');
+                                // Consume the negative sign.
+                                chars.next();
+                            }
+                            let e = peeking_take_while(chars, |ch| match ch {
+                                '0'..='9' => true,
+                                _ => false,
+                            });
+                            s.push_str(&e);
+                        }
+                        _ => {}
+                    }
+
                     Ok(Some(Token::Number(s)))
                 }
                 // punctuation

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -487,6 +487,20 @@ fn parse_number() {
 }
 
 #[test]
+fn parse_approximate_numeric_literal() {
+    let expr = verified_expr("1.0E2");
+
+    #[cfg(feature = "bigdecimal")]
+    assert_eq!(
+        expr,
+        Expr::Value(Value::Number(bigdecimal::BigDecimal::from(10)))
+    );
+
+    #[cfg(not(feature = "bigdecimal"))]
+    assert_eq!(expr, Expr::Value(Value::Number("1.0E2".into())));
+}
+
+#[test]
 fn parse_compound_expr_1() {
     use self::BinaryOperator::*;
     use self::Expr::*;


### PR DESCRIPTION
@benesch This was the cleanest thing I could come up with that only allowed `-` in the position immediately after the `e`/`E`. Let me know if there's another path forward you see.

I also bundled in a small change that only allows for a single decimal point, which mimics Postgres's parsing behavior.