### PR TITLE
parse numbers that begin with decimals

### DIFF
--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -487,6 +487,20 @@ fn parse_number() {
 }
 
 #[test]
+fn parse_numeric_begin_with_decimal() {
+    let expr = verified_expr(".1");
+
+    #[cfg(feature = "bigdecimal")]
+    assert_eq!(
+        expr,
+        Expr::Value(Value::Number(bigdecimal::BigDecimal::from(.1)))
+    );
+
+    #[cfg(not(feature = "bigdecimal"))]
+    assert_eq!(expr, Expr::Value(Value::Number(".1".into())));
+}
+
+#[test]
 fn parse_approximate_numeric_literal() {
     let expr = verified_expr("1.0E2");
 


### PR DESCRIPTION
This library didn't parse `.123` as a number; with this patch, it now does.