### PR TITLE
disable unneeded_field_pattern lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 //! println!("AST: {:?}", ast);
 //! ```
 #![warn(clippy::all)]
+#![allow(clippy::unneeded_field_pattern)]
 
 pub mod ast;
 pub mod dialect;


### PR DESCRIPTION
justification: this lint is lame